### PR TITLE
Update index.d.ts to declare module in TS

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,3 +7,7 @@ declare namespace jestTheories {
      */
     export function theoretically(description: string, theories: any[], testFunction: (theory: any) => void): void
 }
+
+declare module "jest-theories" {
+  export = jestTheories.theoretically;
+}


### PR DESCRIPTION
There is a error when to use jest-theories in TypeScript that "File '`<my project>`/node_modules/jest-theories/index.d.ts' is not a module."
It can be solved by declaring module and export function in `jestTheories` namespace.
See https://github.com/Microsoft/TypeScript/issues/9229#issuecomment-226882914