### PR TITLE
Added counter to format parameters

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -26,6 +26,8 @@ describe('NumberToLongString', () => {
 
 The input string uses [string-format](https://www.npmjs.com/package/string-format) for formatting.
 
+Additionally to the fields available in your theory you can also use `$idx` for the index of the theory and `$no` for the number of the theory.
+
 
 ## Inspiration
 

--- a/index.js
+++ b/index.js
@@ -1,15 +1,18 @@
 import format from 'string-format';
 
 const theoretically = (testName, theories, testFunc) => {
-    if(!test){
+    if (!test) {
         throw new Error('Jest test global must be accessible to use jest-theories');
     }
-    if(!Array.isArray(theories)){
-        throw new Error('Theories must be an array (was '+ typeof theories + ')');
+    if (!Array.isArray(theories)) {
+        throw new Error('Theories must be an array (was ' + typeof theories + ')');
     }
-    
-    theories.forEach(theory => {
-        test(format(testName, theory), testFunc.bind(this, theory));
+
+    theories.forEach((theory, idx) => {
+        test(
+            format(testName, Object.assign({}, theory, { "$idx": idx, "$no": idx + 1 })),
+            testFunc.bind(this, theory)
+        );
     });
 };
 


### PR DESCRIPTION
Added the `$idx` and `$no` variables to be available in the test name

$idx is the index of the theory (0-relative)
$no is the number of the theory (1-relative)

this allows for test names like:
`theoratically("should do something (Test case {$no})", () => {...})`
which resolves to:
- `should do something (Test case 1)`
- `should do something (Test case 2)`
- `should do something (Test case 3)`
- ...