### PR TITLE
Allow for Async tests

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,5 +4,5 @@
  * @param theories theories passed to the test
  * @param testFunction the test which takes a single theory parameter for each time it is executed
  */
-declare function theoretically<T>(description: string | ((theory: T, index: number) => string), theories: T[], testFunction: (theory: T) => void): void;
+declare function theoretically<T>(description: string | ((theory: T, index: number) => string), theories: T[], testFunction: (theory: T) => Promise<void> | void): void;
 export default theoretically;

--- a/index.js
+++ b/index.js
@@ -10,11 +10,12 @@ const theoretically = (testNameCreator, theories, testFunc) => {
 
     const isFunctionTestNameCreator = typeof testNameCreator === 'function';
 
-    if(!isFunctionTestNameCreator && typeof testNameCreator !== 'string') {
+    if (!isFunctionTestNameCreator && typeof testNameCreator !== 'string') {
         throw new Error('Test name creator must be a string or a function')
     }
 
-    theories.forEach((theory, idx) => {
+    for (let idx = 0; idx < theories.length; idx++) {
+        const theory = theories[idx]
         const testName = isFunctionTestNameCreator
             ? testNameCreator(theory, idx)
             : format(testNameCreator, Object.assign({}, theory, { "$idx": idx, "$no": idx + 1 }));
@@ -23,7 +24,7 @@ const theoretically = (testNameCreator, theories, testFunc) => {
             testName,
             testFunc.bind(this, theory)
         );
-    });
+    }
 };
 
 export default theoretically;


### PR DESCRIPTION
Resolving #9 by allowing for async tests to be used

```js
theoretically('an asynchronous test', theories, async (theory) => {
  expect(await somethingAsync(theory.input)).toEqual(theory.expected)
})
```